### PR TITLE
Support multi query ompl planners

### DIFF
--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/cost_convergence_termination_condition.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/cost_convergence_termination_condition.h
@@ -1,0 +1,40 @@
+#include <iostream>
+#include <ompl/base/PlannerTerminationCondition.h>
+namespace ompl_interface
+{
+namespace ob = ompl::base;
+class CostConvergenceTerminationCondition : public ob::PlannerTerminationCondition
+{
+public:
+  CostConvergenceTerminationCondition(size_t solutions_window = 10, double convergence_threshold = 0.9)
+    : ob::PlannerTerminationCondition([] { return false; })
+    , solutions_window_(solutions_window)
+    , convergence_threshold_(convergence_threshold)
+  {
+    std::cout << " test" << std::endl;
+  }
+
+  // Compute the running average cost of the last solutions (solution_window) and terminate if the cost of a
+  // new solution is higher than convergence_threshold times the average cost.
+  void processNewSolution(const std::vector<const ob::State*>& solution_states, const ob::Cost solution_cost)
+  {
+    ++solutions_;
+    size_t solutions = std::min(solutions_, solutions_window_);
+    double new_cost = ((solutions - 1) * average_cost_ + solution_cost.value()) / solutions;
+    double cost_ratio = average_cost_ / new_cost;
+    average_cost_ = new_cost;
+    if (solutions == solutions_window_ && cost_ratio > convergence_threshold_)
+    {
+      std::cout << "Optimizing planner converged after " << solutions_ << " solutions" << std::endl;
+      terminate();
+    }
+  }
+
+private:
+  double average_cost_;
+  size_t solutions_ = 0;
+
+  const size_t solutions_window_;
+  const double convergence_threshold_;
+};
+}

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/cost_convergence_termination_condition.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/cost_convergence_termination_condition.h
@@ -1,4 +1,40 @@
-#include <iostream>
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2019, PickNik LLC
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of PickNik LLC nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Henning Kayser */
+/* Description: A termination condition for early-stopping OMPL* planners based on cost-convergence. */
+
 #include <ompl/base/PlannerTerminationCondition.h>
 namespace ompl_interface
 {
@@ -11,7 +47,6 @@ public:
     , solutions_window_(solutions_window)
     , convergence_threshold_(convergence_threshold)
   {
-    std::cout << " test" << std::endl;
   }
 
   // Compute the running average cost of the last solutions (solution_window) and terminate if the cost of a
@@ -21,11 +56,12 @@ public:
     ++solutions_;
     size_t solutions = std::min(solutions_, solutions_window_);
     double new_cost = ((solutions - 1) * average_cost_ + solution_cost.value()) / solutions;
-    double cost_ratio = average_cost_ / new_cost;
+    double cost_ratio = new_cost / average_cost_;
     average_cost_ = new_cost;
     if (solutions == solutions_window_ && cost_ratio > convergence_threshold_)
     {
-      std::cout << "Optimizing planner converged after " << solutions_ << " solutions" << std::endl;
+      ROS_DEBUG_NAMED("cost_convergence_termination_condition",
+                      "Cost of optimizing planner converged after %lu solutions", solutions_);
       terminate();
     }
   }

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/cost_convergence_termination_condition.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/cost_convergence_termination_condition.h
@@ -51,11 +51,11 @@ public:
 
   // Compute the running average cost of the last solutions (solution_window) and terminate if the cost of a
   // new solution is higher than convergence_threshold times the average cost.
-  void processNewSolution(const std::vector<const ob::State*>& solution_states, const ob::Cost solution_cost)
+  void processNewSolution(const std::vector<const ob::State*>& solution_states, double solution_cost)
   {
     ++solutions_;
     size_t solutions = std::min(solutions_, solutions_window_);
-    double new_cost = ((solutions - 1) * average_cost_ + solution_cost.value()) / solutions;
+    double new_cost = ((solutions - 1) * average_cost_ + solution_cost) / solutions;
     double cost_ratio = new_cost / average_cost_;
     average_cost_ = new_cost;
     if (solutions == solutions_window_ && cost_ratio > convergence_threshold_)

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/persisting_prm_planners.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/detail/persisting_prm_planners.h
@@ -1,0 +1,200 @@
+/*********************************************************************
+* Software License Agreement (BSD License)
+*
+*  Copyright (c) 2019, PickNik LLC
+*  All rights reserved.
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*   * Redistributions of source code must retain the above copyright
+*     notice, this list of conditions and the following disclaimer.
+*   * Redistributions in binary form must reproduce the above
+*     copyright notice, this list of conditions and the following
+*     disclaimer in the documentation and/or other materials provided
+*     with the distribution.
+*   * Neither the name of PickNik LLC nor the names of its
+*     contributors may be used to endorse or promote products derived
+*     from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+*  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+*  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+*  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+*  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+*  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+*  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+*  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+*  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+*  POSSIBILITY OF SUCH DAMAGE.
+*********************************************************************/
+
+/* Author: Henning Kayser */
+/* Description: Support for storing and loading planner data for PRM-based planners. */
+
+#pragma once
+
+#include <ompl/geometric/planners/prm/PRM.h>
+#include <ompl/geometric/planners/prm/LazyPRM.h>
+#include <ompl/tools/config/SelfConfig.h>
+#include <type_traits>
+
+namespace ompl
+{
+namespace geometric
+{
+class PRMPersist : public PRM
+{
+public:
+  PRMPersist(const base::PlannerData& data, bool starStrategy = false) : PRM(data.getSpaceInformation(), starStrategy)
+  {
+    if (data.numVertices() > 0)
+    {
+      std::map<unsigned int, Vertex> vertices;
+      const auto& si = data.getSpaceInformation();
+      const auto& getOrCreateVertex = [&](unsigned int vertex_index) {
+        if (!vertices.count(vertex_index))
+        {
+          const auto& data_vertex = data.getVertex(vertex_index);
+          Vertex graph_vertex = boost::add_vertex(g_);
+          stateProperty_[graph_vertex] = si->cloneState(data_vertex.getState());
+          totalConnectionAttemptsProperty_[graph_vertex] = 1;
+          successfulConnectionAttemptsProperty_[graph_vertex] = 0;
+          vertices[vertex_index] = graph_vertex;
+        }
+        return vertices.at(vertex_index);
+      };
+
+      specs_.multithreaded = false;
+      nn_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Vertex>(this));
+      specs_.multithreaded = true;
+      nn_->setDistanceFunction([this](const Vertex a, const Vertex b) { return distanceFunction(a, b); });
+
+      for (size_t vertex_index = 0; vertex_index < data.numVertices(); ++vertex_index)
+      {
+        Vertex m = getOrCreateVertex(vertex_index);
+        std::vector<unsigned int> neighbor_indices;
+        data.getEdges(vertex_index, neighbor_indices);
+        if (neighbor_indices.empty())
+        {
+          disjointSets_.make_set(m);
+        }
+        else
+        {
+          for (const unsigned int neighbor_index : neighbor_indices)
+          {
+            Vertex n = getOrCreateVertex(neighbor_index);
+            totalConnectionAttemptsProperty_[n]++;
+            successfulConnectionAttemptsProperty_[n]++;
+            base::Cost weight;
+            data.getEdgeWeight(vertex_index, neighbor_index, &weight);
+            const Graph::edge_property_type properties(weight);
+            boost::add_edge(m, n, properties, g_);
+            uniteComponents(m, n);
+          }
+        }
+        nn_->add(m);
+      }
+    }
+  };
+  PRMPersist(const base::SpaceInformationPtr& si, bool starStrategy = false) : PRM(si, starStrategy){};
+};
+class PRMStarPersist : public PRMPersist
+{
+public:
+  PRMStarPersist(const base::PlannerData& data) : PRMPersist(data, true){};
+  PRMStarPersist(const base::SpaceInformationPtr& si) : PRMPersist(si, true){};
+};
+
+class LazyPRMPersist : public LazyPRM
+{
+public:
+  LazyPRMPersist(const base::PlannerData& data, bool starStrategy = false)
+    : LazyPRM(data.getSpaceInformation(), starStrategy)
+  {
+    if (data.numVertices() > 0)
+    {
+      std::map<unsigned int, Vertex> vertices;
+      const auto& si = data.getSpaceInformation();
+      const auto& getOrCreateVertex = [&](unsigned int vertex_index) {
+        if (!vertices.count(vertex_index))
+        {
+          const auto& data_vertex = data.getVertex(vertex_index);
+          Vertex graph_vertex = boost::add_vertex(g_);
+          stateProperty_[graph_vertex] = si->cloneState(data_vertex.getState());
+          vertexValidityProperty_[graph_vertex] = VALIDITY_UNKNOWN;
+          unsigned long int newComponent = componentCount_++;
+          vertexComponentProperty_[graph_vertex] = newComponent;
+          vertices[vertex_index] = graph_vertex;
+        }
+        return vertices.at(vertex_index);
+      };
+
+      specs_.multithreaded = false;
+      nn_.reset(tools::SelfConfig::getDefaultNearestNeighbors<Vertex>(this));
+      specs_.multithreaded = true;
+      nn_->setDistanceFunction([this](const Vertex a, const Vertex b) { return distanceFunction(a, b); });
+
+      for (size_t vertex_index = 0; vertex_index < data.numVertices(); ++vertex_index)
+      {
+        Vertex m = getOrCreateVertex(vertex_index);
+        std::vector<unsigned int> neighbor_indices;
+        data.getEdges(vertex_index, neighbor_indices);
+        for (const unsigned int neighbor_index : neighbor_indices)
+        {
+          Vertex n = getOrCreateVertex(neighbor_index);
+          base::Cost weight;
+          data.getEdgeWeight(vertex_index, neighbor_index, &weight);
+          const Graph::edge_property_type properties(weight);
+          const Edge& edge = boost::add_edge(m, n, properties, g_).first;
+          edgeValidityProperty_[edge] = VALIDITY_UNKNOWN;
+          uniteComponents(m, n);
+        }
+        nn_->add(m);
+      }
+    }
+  };
+  LazyPRMPersist(const base::SpaceInformationPtr& si, bool starStrategy = false) : LazyPRM(si, starStrategy){};
+};
+class LazyPRMStarPersist : public LazyPRMPersist
+{
+public:
+  LazyPRMStarPersist(const base::PlannerData& data) : LazyPRMPersist(data, true){};
+  LazyPRMStarPersist(const base::SpaceInformationPtr& si) : LazyPRMPersist(si, true){};
+};
+}
+}
+namespace
+{
+template <typename T>
+inline ompl::base::Planner* allocatePersistingPlanner(const ompl::base::PlannerData& data)
+{
+  return NULL;
+};
+template <>
+inline ompl::base::Planner* allocatePersistingPlanner<ompl::geometric::PRMPersist>(const ompl::base::PlannerData& data)
+{
+  return new ompl::geometric::PRMPersist(data);
+};
+template <>
+inline ompl::base::Planner*
+allocatePersistingPlanner<ompl::geometric::PRMStarPersist>(const ompl::base::PlannerData& data)
+{
+  return new ompl::geometric::PRMStarPersist(data);
+};
+template <>
+inline ompl::base::Planner*
+allocatePersistingPlanner<ompl::geometric::LazyPRMPersist>(const ompl::base::PlannerData& data)
+{
+  return new ompl::geometric::LazyPRMPersist(data);
+};
+template <>
+inline ompl::base::Planner*
+allocatePersistingPlanner<ompl::geometric::LazyPRMStarPersist>(const ompl::base::PlannerData& data)
+{
+  return new ompl::geometric::LazyPRMStarPersist(data);
+};
+}

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -318,6 +318,8 @@ protected:
   virtual void useConfig();
   virtual ob::GoalPtr constructGoal();
 
+  ob::PlannerTerminationCondition getPlannerTerminationCondition(
+      double timeout, const std::shared_ptr<ob::PlannerTerminationCondition>& ptc_or = nullptr);
   void registerTerminationCondition(const ob::PlannerTerminationCondition& ptc);
   void unregisterTerminationCondition();
 

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -375,6 +375,9 @@ protected:
 
   bool use_state_validity_cache_;
 
+  /// clears planners that don't support multi-query use before running solve()
+  bool multi_query_planning_enabled_;
+
   bool simplify_solutions_;
 };
 }  // namespace ompl_interface

--- a/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
+++ b/moveit_planners/ompl/ompl_interface/include/moveit/ompl_interface/model_based_planning_context.h
@@ -319,7 +319,7 @@ protected:
   virtual ob::GoalPtr constructGoal();
 
   ob::PlannerTerminationCondition getPlannerTerminationCondition(
-      double timeout, const std::shared_ptr<ob::PlannerTerminationCondition>& ptc_or = nullptr);
+      double ptc_timeout, const std::shared_ptr<ob::PlannerTerminationCondition>& alternative_ptc = nullptr);
   void registerTerminationCondition(const ob::PlannerTerminationCondition& ptc);
   void unregisterTerminationCondition();
 

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -729,11 +729,11 @@ bool ompl_interface::ModelBasedPlanningContext::solve(double timeout, unsigned i
 }
 
 ompl::base::PlannerTerminationCondition ompl_interface::ModelBasedPlanningContext::getPlannerTerminationCondition(
-    double timeout, const std::shared_ptr<ob::PlannerTerminationCondition>& ptc_or)
+    double ptc_timeout, const std::shared_ptr<ob::PlannerTerminationCondition>& alternative_ptc)
 {
-  ob::PlannerTerminationCondition ptc = ob::timedPlannerTerminationCondition(timeout);
-  if (ptc_or)
-    return ob::plannerOrTerminationCondition(ptc, *ptc_or);
+  ob::PlannerTerminationCondition ptc = ob::timedPlannerTerminationCondition(ptc_timeout);
+  if (alternative_ptc)
+    return ob::plannerOrTerminationCondition(ptc, *alternative_ptc);
   else
     return ptc;
 }

--- a/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/model_based_planning_context.cpp
@@ -333,8 +333,8 @@ void ompl_interface::ModelBasedPlanningContext::useConfig()
     std::string type = it->second;
     cfg.erase(it);
     const std::string planner_name = getGroupName() + "/" + name_;
-    ompl_simple_setup_->setPlannerAllocator(std::bind(spec_.planner_selector_(type), std::placeholders::_1,
-                                                      planner_name, std::cref(spec_)));
+    ompl_simple_setup_->setPlannerAllocator(
+        std::bind(spec_.planner_selector_(type), std::placeholders::_1, planner_name, std::cref(spec_)));
     ROS_INFO_NAMED("model_based_planning_context",
                    "Planner configuration '%s' will use planner '%s'. "
                    "Additional configuration parameters will be set when the planner is constructed.",

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -117,6 +117,7 @@ static ompl::base::PlannerPtr allocatePlanner(const ob::SpaceInformationPtr& si,
   planner->setup();
   return planner;
 }
+
 }  // namespace
 
 ompl_interface::ConfiguredPlannerAllocator
@@ -136,77 +137,100 @@ void ompl_interface::PlanningContextManager::registerDefaultPlanners()
 {
   registerPlannerAllocator(  //
       "geometric::RRT",      //
-      std::bind(&allocatePlanner<og::RRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::RRT>(si, new_name, spec);});
   registerPlannerAllocator(     //
       "geometric::RRTConnect",  //
-      std::bind(&allocatePlanner<og::RRTConnect>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::RRTConnect>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::LazyRRT",  //
-      std::bind(&allocatePlanner<og::LazyRRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::LazyPRM>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::TRRT",     //
-      std::bind(&allocatePlanner<og::TRRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::TRRT>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::EST",      //
-      std::bind(&allocatePlanner<og::EST>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::EST>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::SBL",      //
-      std::bind(&allocatePlanner<og::SBL>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::SBL>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::KPIECE",   //
-      std::bind(&allocatePlanner<og::KPIECE1>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::KPIECE1>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::BKPIECE",  //
-      std::bind(&allocatePlanner<og::BKPIECE1>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::BKPIECE1>(si, new_name, spec);});
   registerPlannerAllocator(   //
       "geometric::LBKPIECE",  //
-      std::bind(&allocatePlanner<og::LBKPIECE1>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::LBKPIECE1>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::RRTstar",  //
-      std::bind(&allocatePlanner<og::RRTstar>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::RRTstar>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::PRM",      //
-      std::bind(&allocatePlanner<og::PRM>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::PRM>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::PRMstar",  //
-      std::bind(&allocatePlanner<og::PRMstar>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::PRMstar>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::FMT",      //
-      std::bind(&allocatePlanner<og::FMT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::FMT>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::BFMT",     //
-      std::bind(&allocatePlanner<og::BFMT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::BFMT>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::PDST",     //
-      std::bind(&allocatePlanner<og::PDST>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::PDST>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::STRIDE",   //
-      std::bind(&allocatePlanner<og::STRIDE>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::STRIDE>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::BiTRRT",   //
-      std::bind(&allocatePlanner<og::BiTRRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::BiTRRT>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::LBTRRT",   //
-      std::bind(&allocatePlanner<og::LBTRRT>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::LBTRRT>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::BiEST",    //
-      std::bind(&allocatePlanner<og::BiEST>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::BiEST>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::ProjEST",  //
-      std::bind(&allocatePlanner<og::ProjEST>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::ProjEST>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::LazyPRM",  //
-      std::bind(&allocatePlanner<og::LazyPRM>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::LazyPRM>(si, new_name, spec);});
   registerPlannerAllocator(      //
       "geometric::LazyPRMstar",  //
-      std::bind(&allocatePlanner<og::LazyPRMstar>, std::placeholders::_1, std::placeholders::_2,
-                std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::LazyPRMstar>(si, new_name, spec);});
   registerPlannerAllocator(  //
       "geometric::SPARS",    //
-      std::bind(&allocatePlanner<og::SPARS>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::SPARS>(si, new_name, spec);});
   registerPlannerAllocator(   //
       "geometric::SPARStwo",  //
-      std::bind(&allocatePlanner<og::SPARStwo>, std::placeholders::_1, std::placeholders::_2, std::placeholders::_3));
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::SPARStwo>(si, new_name, spec);});
 }
 
 void ompl_interface::PlanningContextManager::registerDefaultStateSpaces()

--- a/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
+++ b/moveit_planners/ompl/ompl_interface/src/planning_context_manager.cpp
@@ -67,6 +67,7 @@
 #include <ompl/geometric/planners/prm/LazyPRMstar.h>
 #include <ompl/geometric/planners/prm/SPARS.h>
 #include <ompl/geometric/planners/prm/SPARStwo.h>
+#include <moveit/ompl_interface/detail/persisting_prm_planners.h>
 
 #include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space_factory.h>
 #include <moveit/ompl_interface/parameterization/joint_space/joint_model_state_space.h>
@@ -138,99 +139,171 @@ void ompl_interface::PlanningContextManager::registerDefaultPlanners()
   registerPlannerAllocator(  //
       "geometric::RRT",      //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::RRT>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::RRT>(si, new_name, spec);
+      });
   registerPlannerAllocator(     //
       "geometric::RRTConnect",  //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::RRTConnect>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::RRTConnect>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::LazyRRT",  //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::LazyPRM>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::LazyPRM>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::TRRT",     //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::TRRT>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::TRRT>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::EST",      //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::EST>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::EST>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::SBL",      //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::SBL>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::SBL>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::KPIECE",   //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::KPIECE1>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::KPIECE1>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::BKPIECE",  //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::BKPIECE1>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::BKPIECE1>(si, new_name, spec);
+      });
   registerPlannerAllocator(   //
       "geometric::LBKPIECE",  //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::LBKPIECE1>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::LBKPIECE1>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::RRTstar",  //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::RRTstar>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::RRTstar>(si, new_name, spec);
+      });
+  registerPlannerAllocator(     //
+      "geometric::PRMPersist",  //
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::PRMPersist>(si, new_name, spec);
+      });
+  registerPlannerAllocator(         //
+      "geometric::PRMStarPersist",  //
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::PRMStarPersist>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::PRM",      //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::PRM>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::PRM>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::PRMstar",  //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::PRMstar>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::PRMstar>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::FMT",      //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::FMT>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::FMT>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::BFMT",     //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::BFMT>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::BFMT>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::PDST",     //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::PDST>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::PDST>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::STRIDE",   //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::STRIDE>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::STRIDE>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::BiTRRT",   //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::BiTRRT>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::BiTRRT>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::LBTRRT",   //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::LBTRRT>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::LBTRRT>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::BiEST",    //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::BiEST>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::BiEST>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::ProjEST",  //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::ProjEST>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::ProjEST>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::LazyPRM",  //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::LazyPRM>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::LazyPRM>(si, new_name, spec);
+      });
   registerPlannerAllocator(      //
       "geometric::LazyPRMstar",  //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::LazyPRMstar>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::LazyPRMstar>(si, new_name, spec);
+      });
+  registerPlannerAllocator(         //
+      "geometric::LazyPRMPersist",  //
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::LazyPRMPersist>(si, new_name, spec);
+      });
+  registerPlannerAllocator(             //
+      "geometric::LazyPRMStarPersist",  //
+      [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::LazyPRMStarPersist>(si, new_name, spec);
+      });
   registerPlannerAllocator(  //
       "geometric::SPARS",    //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::SPARS>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::SPARS>(si, new_name, spec);
+      });
   registerPlannerAllocator(   //
       "geometric::SPARStwo",  //
       [&](const ob::SpaceInformationPtr& si, const std::string& new_name,
-          const ModelBasedPlanningContextSpecification& spec){return planner_allocator_.allocatePlanner<og::SPARStwo>(si, new_name, spec);});
+          const ModelBasedPlanningContextSpecification& spec) {
+        return planner_allocator_.allocatePlanner<og::SPARStwo>(si, new_name, spec);
+      });
 }
 
 void ompl_interface::PlanningContextManager::registerDefaultStateSpaces()


### PR DESCRIPTION
This implements support for reusing OMPL planner data over multiple planning runs.
If enabled, planner instances are stored and kept alive during runtime so that roadmaps are reused and grown with each new planning attempt.
Supported planners are (https://ompl.kavrakilab.org/planners.html):
* PRM, PRMstar
* LazyPRM, LazyPRMstar
* SPARS, SPARS2

This feature can be enabled by setting `multi_query_planning_enabled: true` for the corresponding algorithms inside the `ompl_planning.yaml`.

I ran a short benchmark of a pre-trained PRM (here "PRMMultiQuery") against RRTConnect and a PRM with this multi-query feature disabled. Training and benchmark was run over all predefined poses, 42 queries per run. Training was only run for a single iteration with planning time set to 0.3 to give PRMMultiQuery time to grow a roadmap. The benchmark was run over 50 iterations adding up to 2100 planning attempts per planner. Since PRM planners use the maximum planning time available I set the limit to 0.05s which is enough for RRTConnect. Even with this low planning time, PRM with multi-query enabled had the lowest failure rate (out of 2100).

PRM: 462 failures ~ 22%
PRMMultiQuery: 25 failures ~ 0.012 %
RRTConnect: 27 failures ~ 0.013%

The biggest advantage of this feature is that multi-query solutions are much more repeatable compared to the other planners while still allowing planning times about as fast as RRTConnect:

![average_distance_boxes](https://user-images.githubusercontent.com/4572766/63607359-95e30d00-c5d2-11e9-9937-0a0a27f23e83.png)

The outliers can be explained by incomplete training or even ongoing training process during the benchmark. Other metrics like path length and smoothness are slightly better than with RRTConnect.

Currently, even if the basic planner implementation would allow it, the API for OMPL's default planners doesn't allow loading planner data into new planner instances.  It would be straight-forward to add this feature from the MoveIt side, but we need to discuss adding this capability to OMPL. Currently, this method would require pre-training the planner with each new launch.
The same shortcoming of the OMPL interfaces also doesn't allow us to limit path growth to a fixed number of states. However, it's possible to throttle the growth rate by using very short planning times (<0.03s). 